### PR TITLE
Create index.htm to serve dwr docs with GitHub Pages

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1,0 +1,9 @@
+ <html xmlns="http://www.w3.org/1999/xhtml">    
+  <head>      
+    <title>DWR DOC</title>      
+    <meta http-equiv="refresh" content="0;URL='target/publish/dwr'" />    
+  </head>    
+  <body> 
+    <p>Redirecting to <a href="target/publish/dwr"></p> 
+  </body>  
+</html>


### PR DESCRIPTION
use GitHub pages to serve content from target/publish/dwr since directwebremoting.org is defunct. see directwebremoting/dwr#43

works here https://mikekonikoff.github.io/docdwr/

pages settings
![image](https://user-images.githubusercontent.com/6537722/190219254-84d39b22-4a7b-4f31-a45d-caa212b09af1.png)
